### PR TITLE
Show total cost for run

### DIFF
--- a/src/lib/components/run-results/run-results-table.svelte
+++ b/src/lib/components/run-results/run-results-table.svelte
@@ -86,7 +86,16 @@
 
 	let showVarsColumns = true;
 	$: $hiddenColumnIds = showVarsColumns ? [] : varNames;
+
+	// Add a computed property to sum the total cost of all tests in the run
+	$: totalCost = run.results.flat().reduce((sum, result) => {
+		return sum + (result.tokenUsage?.costDollars ?? 0);
+	}, 0);
 </script>
+
+<div class="text-right mb-2">
+	Total Cost: ${totalCost.toFixed(4)}
+</div>
 
 <input id="run-{run.id}-{run.timestamp}" type="checkbox" bind:checked={showVarsColumns} />
 <label for="run-{run.id}-{run.timestamp}">Show vars columns</label>


### PR DESCRIPTION
Related to #12

Add total cost display for a run of tests.

* Add a computed property to sum the total cost of all tests in the run in `src/lib/components/run-results/run-results-table.svelte`.
* Display the total cost above the table in `src/lib/components/run-results/run-results-table.svelte`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tbuckley/evals-pwa/issues/12?shareId=5e0cb374-6636-4195-a304-795685cdc301).