### PR TITLE
feat: JS/TS files become CodeReferences

### DIFF
--- a/examples/refs/code.ts
+++ b/examples/refs/code.ts
@@ -1,4 +1,4 @@
 import { prompt } from './module.ts';
-export function execute(): string {
+export default function execute(): string {
 	return 'typescript ' + prompt;
 }

--- a/src/lib/storage/CodeReference.ts
+++ b/src/lib/storage/CodeReference.ts
@@ -1,0 +1,64 @@
+import * as esbuild from 'esbuild-wasm';
+import type { FileStorage } from './dereferenceFilePaths';
+import { FileReference } from './FileReference';
+
+let esbuildReady: Promise<void> | undefined;
+function lazyInitEsbuild() {
+	if (!esbuildReady) {
+		esbuildReady = new Promise<void>((resolve) => {
+			esbuild
+				.initialize({
+					wasmURL: new URL('../../../node_modules/esbuild-wasm/esbuild.wasm', import.meta.url).href
+				})
+				.then(resolve);
+		});
+	}
+	return esbuildReady;
+}
+
+export class CodeReference extends FileReference {
+	readonly #storage: FileStorage;
+	constructor(uri: string, file: File, storage: FileStorage) {
+		super(uri, file);
+		this.#storage = storage;
+	}
+	async getCode() {
+		if (this.file.name.endsWith('.ts')) {
+			await lazyInitEsbuild();
+			const storage = this.#storage;
+			const loader: esbuild.Plugin = {
+				name: 'file loader',
+				setup(build) {
+					build.onResolve({ filter: /.*/ }, (args) => {
+						const importer = args.importer === '' ? undefined : args.importer;
+						const path = new URL(args.path, importer).toString();
+						return { path, namespace: 'virtual' };
+					});
+					build.onLoad({ filter: /.*/, namespace: 'virtual' }, async (args) => {
+						const file = await storage.load(args.path);
+						if (Array.isArray(file)) {
+							throw new Error('cant load a glob');
+						}
+						const contents = await file.text();
+						return {
+							contents,
+							loader: 'ts'
+						};
+					});
+				}
+			};
+			const result = await esbuild.build({
+				plugins: [loader],
+				entryPoints: [this.uri],
+				target: 'es2022',
+				format: 'esm',
+				bundle: true
+			});
+			if (result.errors.length) {
+				throw new Error(result.errors.map((value) => value.text).join('\n'));
+			}
+			return result.outputFiles![0].text;
+		}
+		return await this.file.text();
+	}
+}

--- a/src/lib/storage/dereferenceFilePaths.test.ts
+++ b/src/lib/storage/dereferenceFilePaths.test.ts
@@ -142,14 +142,29 @@ describe('dereferenceFilePaths', () => {
 
 		const input = { tests: ['file:///tests/a.yaml'] };
 		const output = await dereferenceFilePaths(input, { storage });
-		expect(output).toMatchObject({
-			tests: [{ vars: { foo: 1, bar: 2 }, assert: 'code', abs: 'code' }]
-		});
-		expect(output)
-			.property('tests')
-			.property('0')
-			.property('vars')
-			.property('baz')
-			.to.be.instanceOf(FileReference);
+		expect(output).toMatchInlineSnapshot(`
+			{
+			  "tests": [
+			    {
+			      "abs": CodeReference {
+			        "file": File {},
+			        "uri": "file:///assert.js",
+			      },
+			      "assert": CodeReference {
+			        "file": File {},
+			        "uri": "file:///assert.js",
+			      },
+			      "vars": {
+			        "bar": 2,
+			        "baz": FileReference {
+			          "file": File {},
+			          "uri": "file:///tests/baz/c.png",
+			        },
+			        "foo": 1,
+			      },
+			    },
+			  ],
+			}
+		`);
 	});
 });

--- a/src/lib/storage/runGenerators.ts
+++ b/src/lib/storage/runGenerators.ts
@@ -1,7 +1,8 @@
 import { CodeSandbox } from '$lib/utils/CodeSandbox';
+import type { CodeReference } from './CodeReference';
 
 interface Generator {
-	'=gen': string;
+	'=gen': string | CodeReference;
 	args?: unknown[];
 }
 
@@ -35,7 +36,8 @@ export async function runGenerators(target: any) {
 		return target;
 	}
 	if (isGenerator(target)) {
-		const sandbox = new CodeSandbox(target['=gen']);
+		const ref = target['=gen'];
+		const sandbox = new CodeSandbox(ref);
 		try {
 			const args = ensureArray(target['args']);
 			return await sandbox.execute(...args);

--- a/tests/fileSystem.test.ts
+++ b/tests/fileSystem.test.ts
@@ -51,7 +51,7 @@ test.describe('File System', () => {
 			'Equals a value',
 			'Is >1000 characters',
 
-			'function execute(output)',
+			'"uri": "file:///code.js"',
 			'"word": "there"',
 
 			'typescript prompt'


### PR DESCRIPTION
Also changes the loading behavior for TS bundles to load as modules with a default export, otherwise it's not guaranteed which function would actually be named `execute`.