### PR TITLE
Test nullish OpenAI response handling

### DIFF
--- a/src/lib/providers/openai.test.ts
+++ b/src/lib/providers/openai.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { describe, expect, test } from 'vitest';
+import { OpenaiProvider } from './openai';
+
+describe('OpenaiProvider', () => {
+  const provider = new OpenaiProvider('gpt-test', 'test-key');
+
+  test('extractDeltaOutput handles null and undefined', () => {
+    const nullDelta = { id: '1', choices: [{ delta: { content: null } }] };
+    const undefinedDelta = { id: '1', choices: [{ delta: {} }] };
+    expect(provider.extractDeltaOutput(nullDelta)).toBe('');
+    expect(provider.extractDeltaOutput(undefinedDelta)).toBe('');
+  });
+
+  test('extractOutput handles null and undefined', () => {
+    const nullMessage = {
+      id: '1',
+      choices: [{ message: { role: 'assistant', content: null } }],
+    };
+    const undefinedMessage = {
+      id: '1',
+      choices: [{ message: { role: 'assistant' } }],
+    };
+    expect(provider.extractOutput(nullMessage)).toEqual(['']);
+    expect(provider.extractOutput(undefinedMessage)).toEqual(['']);
+  });
+});

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -21,13 +21,13 @@ const generateContentResponseSchema = z.object({
     z.object({
       message: z
         .object({
-          content: z.string().nullable(),
+          content: z.string().nullish(),
           role: z.string(),
         })
         .optional(),
       delta: z
         .object({
-          content: z.string().optional(),
+          content: z.string().nullish(),
         })
         .optional(),
     }),
@@ -176,6 +176,9 @@ export class OpenaiProvider implements ModelProvider {
     const firstChoice = json.choices[0].message?.content;
     if (typeof firstChoice === 'string') {
       return [firstChoice];
+    }
+    if (firstChoice == null) {
+      return [''];
     }
 
     throw new Error('Unexpected output format');


### PR DESCRIPTION
Necessary to support llama-server.

## Summary
- handle `delta` and `message` content that may be `null` or `undefined`
- gracefully extract empty output when full content is missing
- test OpenAI provider against nullish `delta` and `message` content

## Testing
- `CI=1 npm run test` *(fails: Timed out waiting 60000ms from config.webServer.)*
- `CI=1 npx vitest run src/lib/providers/openai.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b3aa4ed388832abc5fa4a7afe8c77a